### PR TITLE
New component: List all posts (with pagination)

### DIFF
--- a/wp-gatsby-testsite/gatsby-node.js
+++ b/wp-gatsby-testsite/gatsby-node.js
@@ -30,11 +30,10 @@ exports.createPages = async ({ graphql, actions }) => {
   const postTemplate = path.resolve(`./src/templates/post.js`)
   const pageTemplate = path.resolve(`./src/templates/page.js`)
 
+  // Create one unique page per WP post
   allPosts.forEach(post => {
     createPage({
-      // will be the url for the page
       path: post.uri,
-      // specify the component template of your choice
       component: slash(postTemplate),
       // In the ^template's GraphQL query, 'id' will be available
       // as a GraphQL variable to query for this post's data.
@@ -44,109 +43,35 @@ exports.createPages = async ({ graphql, actions }) => {
     })
   })
 
+  // Create one unique page per WP page
   allPages.forEach(page => {
     createPage({
       path: page.uri,
       component: slash(pageTemplate),
+      // In the ^template's GraphQL query, 'id' will be available
+      // as a GraphQL variable to query for this post's data.
       context: {
         id: page.id,
       },
     })
   })
-}
 
-/* 
-// Optional code (may need some customization): 
-// 
-// Make Wordpress media files available as static files in Gatsby
-// so that it's possible to use the gatsby-image plugin for transformation/optimization
-// The files are cached, to reduce build time
-// Code by Henrik Wirth: https://dev.to/nevernull/gatsby-with-wpgraphql-acf-and-gatbsy-image-72m
-// and Robert Marshall: https://dev.to/robmarshall/gatsby-with-wordpress-caching-downloaded-media-images-to-reduce-build-time-1d2m
+  // Create post list pages showing all posts
+  const postsPerPage = 4
+  const numPages = Math.ceil(allPosts.length / postsPerPage)
 
-exports.createResolvers = ({
-  actions,
-  cache,
-  createNodeId,
-  createResolvers,
-  getNode,
-  store,
-  reporter,
-}) => {
-  const { createNode, touchNode } = actions
-
-  // Add all media libary images so they can be queried by
-  // childImageSharp
-  createResolvers({
-    WPGraphQL_MediaItem: {
-      imageFile: {
-        type: `File`,
-        async resolve(source, args, context, info) {
-          if (source.sourceUrl) {
-            let fileNodeID
-            let fileNode
-            let sourceModified
-
-            // Set the file cacheID, get it (if it has already been set)
-            const mediaDataCacheKey = `wordpress-media-${source.mediaItemId}`
-            const cacheMediaData = await cache.get(mediaDataCacheKey)
-
-            if (source.modified) {
-              sourceModified = source.modified
-            }
-
-            // If we have cached media data and it wasn't modified, reuse
-            // previously created file node to not try to redownload
-            if (cacheMediaData && sourceModified === cacheMediaData.modified) {
-              fileNode = getNode(cacheMediaData.fileNodeID)
-
-              // check if node still exists in cache
-              // it could be removed if image was made private
-              if (fileNode) {
-                fileNodeID = cacheMediaData.fileNodeID
-                // https://www.gatsbyjs.org/docs/node-creation/#freshstale-nodes
-                touchNode({
-                  nodeId: fileNodeID,
-                })
-              }
-            }
-
-            // If we don't have cached data, download the file
-            if (!fileNodeID) {
-              try {
-                // Get the filenode
-                fileNode = await createRemoteFileNode({
-                  url: source.sourceUrl,
-                  store,
-                  cache,
-                  createNode,
-                  createNodeId,
-                  reporter,
-                })
-
-                if (fileNode) {
-                  fileNodeID = fileNode.id
-
-                  await cache.set(mediaDataCacheKey, {
-                    fileNodeID,
-                    modified: sourceModified,
-                  })
-                }
-              } catch (e) {
-                // Ignore
-                console.log(e)
-                return null
-              }
-            }
-
-            if (fileNode) {
-              return fileNode
-            }
-          }
-          return null
-        },
+  Array.from({ length: numPages }).forEach((_, i) => {
+    createPage({
+      path: i === 0 ? `/allposts/` : `/allposts/${i + 1}`,
+      component: path.resolve("./src/templates/post-list.js"),
+      // In the ^template's GraphQL query, these variables will be
+      // available to query for this post's data.
+      context: {
+        limit: postsPerPage,
+        skip: i * postsPerPage,
+        numPages,
+        currentPage: i + 1,
       },
-    },
+    })
   })
 }
- */

--- a/wp-gatsby-testsite/src/components/postPreviewGrid.js
+++ b/wp-gatsby-testsite/src/components/postPreviewGrid.js
@@ -26,6 +26,10 @@ const PostPreviewGrid = props => {
           </li>
         ))}
       </ul>
+
+      <Link to="/allposts/" className={styles.allPostsLink}>
+        <h3 className={styles.allPostsLink}>{`>> View all posts`}</h3>
+      </Link>
     </div>
   )
 }

--- a/wp-gatsby-testsite/src/components/postPreviewGrid.module.css
+++ b/wp-gatsby-testsite/src/components/postPreviewGrid.module.css
@@ -35,11 +35,12 @@
 
   @media (--media-min-large) {
     grid-template-columns: 1fr 1fr 1fr;
+    margin-bottom: 0;
   }
 }
 
 .listItem {
-  margin: 0 15px -20px 10px;
+  margin: 0 15px 0 10px;
   padding: 10px;
 
   @media (--media-min-medium) {
@@ -67,4 +68,12 @@
   font-family: var(--font-family-txt);
   font-size: var(--font-base-size);
   text-decoration: none;
+}
+
+.allPostsLink {
+  margin: 0;
+}
+
+.allPostsLink h3 {
+  padding-left: 25px;
 }

--- a/wp-gatsby-testsite/src/styles/custom-properties.css
+++ b/wp-gatsby-testsite/src/styles/custom-properties.css
@@ -8,14 +8,14 @@
   --font-family-sans: "Josefin Sans", sans-serif;
   --font-family-txt: "Lato", sans-serif;
 
-  --color-maintext: rgb(22, 22, 22);
+  --color-maintext: #111;
   --color-text2: #fff;
   --color-text3: #697a90;
   --color-text4: #fff;
   --color-background: #e2e2e2;
   --color-background2: #252626;
   --color-background3: #e7ebed;
-  --color-accent: rgb(101, 90, 122);
+  --color-accent: #777;
   --color-logo1: #1d1b1a;
   --color-logo2: #014074;
 

--- a/wp-gatsby-testsite/src/templates/page.js
+++ b/wp-gatsby-testsite/src/templates/page.js
@@ -7,7 +7,7 @@ import { graphql } from "gatsby"
 import Layout from "../components/layout"
 import styles from "./post.module.css"
 
-const pageTemplate = ({ data }) => {
+const PageTemplate = ({ data }) => {
   const { page } = data
   const { title, content } = page
   return (
@@ -24,7 +24,7 @@ const pageTemplate = ({ data }) => {
     </Layout>
   )
 }
-export default pageTemplate
+export default PageTemplate
 
 // The $id comes from the createPage function in gatsby-node.js
 // Query the page with this ID, and use it in this template

--- a/wp-gatsby-testsite/src/templates/post-list.js
+++ b/wp-gatsby-testsite/src/templates/post-list.js
@@ -1,0 +1,96 @@
+// Template used for programmatically creating
+// archive pages listing all posts. Data is fetched from Wordpress
+// Used by the createPage function in gatsby-node.js
+
+import React from "react"
+import { Link, graphql } from "gatsby"
+
+import Layout from "../components/layout"
+import styles from "./post-list.module.css"
+
+const PostList = props => {
+  const { data } = props
+  const posts = data && data.posts
+  const { currentPage, numPages } = props.pageContext
+  const isFirst = currentPage === 1
+  const isLast = currentPage === numPages
+  const prevPage = currentPage - 1 === 1 ? "/" : (currentPage - 1).toString()
+  const nextPage = (currentPage + 1).toString()
+
+  return (
+    <Layout>
+      <div className={styles.postContainer}>
+        <h1>Alle innlegg</h1>
+        {posts.nodes.map(post => {
+          return (
+            <div key={post.id}>
+              <Link to={post.uri}>
+                <h3>{post.title}</h3>
+              </Link>
+              <p dangerouslySetInnerHTML={{ __html: post.excerpt }} />
+            </div>
+          )
+        })}
+
+        <ul className={styles.pageNav}>
+          {!isFirst && (
+            <Link
+              to={`/allposts/${prevPage}`}
+              rel="prev"
+              className={styles.paginationLeft}
+            >
+              &#171; Previous Page
+            </Link>
+          )}
+          {Array.from({ length: numPages }, (_, i) => (
+            <li key={`pagination-number${i + 1}`}>
+              <Link
+                to={`/allposts/${i === 0 ? "" : i + 1}`}
+                className={`${styles.listItem} ${
+                  i + 1 === currentPage ? styles.selected : ""
+                }`}
+              >
+                {i + 1}...
+              </Link>
+            </li>
+          ))}
+          {!isLast && (
+            <Link
+              to={`/allposts/${nextPage}`}
+              rel="next"
+              className={styles.paginationRight}
+            >
+              Next Page &#187;
+            </Link>
+          )}
+        </ul>
+      </div>
+    </Layout>
+  )
+}
+
+export default PostList
+
+export const query = graphql`
+  query postPageQuery($skip: Int!, $limit: Int!) {
+    site {
+      siteMetadata {
+        title
+      }
+    }
+    posts: allWpPost(
+      sort: { fields: date, order: DESC }
+      limit: $limit
+      skip: $skip
+    ) {
+      nodes {
+        id
+        uri
+        excerpt
+        slug
+        date(formatString: "DD. MMMM YYYY", locale: "NB-NO")
+        title
+      }
+    }
+  }
+`

--- a/wp-gatsby-testsite/src/templates/post-list.module.css
+++ b/wp-gatsby-testsite/src/templates/post-list.module.css
@@ -1,0 +1,93 @@
+@import "../styles/custom-media.css";
+@import "../styles/custom-properties.css";
+
+.blogTitle {
+  font-family: var(--font-family-sans);
+  font-size: var(--font-title1-size);
+}
+
+.blogText {
+  font-family: var(--font-family-txt);
+  font-size: var(--font-base-size);
+}
+
+.postContainer {
+  margin: 10px 20px 40px -10px;
+  padding: 0;
+  list-style: none;
+  display: block;
+
+  @media (--media-min-medium) {
+    margin-left: 10px;
+  }
+
+  @media (--media-min-large) {
+    margin-left: 40px;
+    margin-right: 30vw;
+  }
+}
+
+.postContainer figure {
+  margin-left: 20px;
+  margin-right: 0;
+  padding: 0;
+
+  @media (--media-min-medium) {
+    margin-left: 10px;
+  }
+
+  @media (--media-min-large) {
+    margin-left: 20px;
+  }
+}
+
+.postContainer figure img {
+  width: 90vw;
+}
+
+.postContainer > div > p,
+h1,
+h2,
+h3,
+h4 {
+  padding-left: 20px;
+}
+
+.pageNav {
+  display: flex;
+  list-style: none;
+  display: flex;
+  flex-flow: wrap;
+  justify-content: align-left;
+  margin-top: 20px;
+}
+
+.pageNav > li,
+a {
+  margin: 0;
+  padding-right: 5px;
+  text-decoration: none;
+}
+
+.paginationLeft {
+  color: var(--color-accent);
+  font-weight: bold;
+  padding-right: 2em;
+}
+.paginationRight {
+  color: var(--color-accent);
+  font-weight: bold;
+  padding-left: 2em;
+}
+.listItem {
+  color: var(--color-accent);
+  font-weight: normal;
+}
+
+.selected {
+  font-weight: bold;
+}
+
+.allPostsLink {
+  color: red;
+}

--- a/wp-gatsby-testsite/src/templates/post.js
+++ b/wp-gatsby-testsite/src/templates/post.js
@@ -7,7 +7,7 @@ import { graphql } from "gatsby"
 import Layout from "../components/layout"
 import styles from "./post.module.css"
 
-const postTemplate = ({ data }) => {
+const PostTemplate = ({ data }) => {
   const { page } = data
   const { title, content } = page
   return (
@@ -24,7 +24,7 @@ const postTemplate = ({ data }) => {
     </Layout>
   )
 }
-export default postTemplate
+export default PostTemplate
 
 // The $id comes from the createPage function in gatsby-node.js
 // Query the post with this ID, and use it in this template


### PR DESCRIPTION
(Issue #12)

- Updated gatsby-node.js with code to automatically create pages listing all Wordpress posts, using the template` post-list.js`. The number of posts on each page is defined by the constant `postsPerPage `in `gatsby-node.js`. 
- Pagination at the bottom of `post-list.js`.
- Linked to the new all posts pages at the bottom of `postPreviewGrid.js`, which is shown on the front page
- The new all posts pages are available at /allposts/, /allposts/2, etc.